### PR TITLE
Updating rxjs to version 6.0.0

### DIFF
--- a/src/createLogicAction$.js
+++ b/src/createLogicAction$.js
@@ -2,7 +2,7 @@ import {take, defaultIfEmpty, takeUntil, tap, mergeAll} from 'rxjs/operators';
 import { timer, from, throwError, of, Observable, Subject } from 'rxjs';
 import isPromise from 'is-promise';
 import { confirmProps, isObservable } from './utils';
-
+// manual changes
 // confirm custom Rx build imports
 confirmProps(Observable, ['fromPromise', 'of', 'throw', 'timer'],
              'Observable');

--- a/src/createLogicAction$.js
+++ b/src/createLogicAction$.js
@@ -1,17 +1,6 @@
+import {take, defaultIfEmpty, takeUntil, tap, mergeAll} from 'rxjs/operators';
+import { timer, from, throwError, of, Observable, Subject } from 'rxjs';
 import isPromise from 'is-promise';
-import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
-import 'rxjs/add/observable/fromPromise';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/throw';
-import 'rxjs/add/observable/timer';
-import 'rxjs/add/operator/defaultIfEmpty';
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/filter';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/mergeAll';
-import 'rxjs/add/operator/take';
-import 'rxjs/add/operator/takeUntil';
 import { confirmProps, isObservable } from './utils';
 
 // confirm custom Rx build imports
@@ -42,8 +31,7 @@ export default function createLogicAction$({ action, logic, store, deps, cancel$
   const logicAction$ = Observable.create(logicActionObs => {
     // create notification subject for process which we dispose of
     // when take(1) or when we are done dispatching
-    const cancelled$ = (new Subject())
-          .take(1);
+    const cancelled$ = (new Subject()).pipe(take(1));
     cancel$.subscribe(cancelled$); // connect cancelled$ to cancel$
     cancelled$
       .subscribe(
@@ -60,24 +48,17 @@ export default function createLogicAction$({ action, logic, store, deps, cancel$
     // will console.error if logic has not completed by the time it fires
     // warnTimeout can be set to 0 to disable
     if (NODE_ENV !== 'production' && warnTimeout) {
-      Observable.timer(warnTimeout)
-        // take until cancelled, errored, or completed
-        .takeUntil(cancelled$.defaultIfEmpty(true))
-        .do(() => {
+      timer(warnTimeout).pipe(takeUntil(cancelled$.pipe(defaultIfEmpty(true))), tap(() => {
           // eslint-disable-next-line no-console
           console.error(`warning: logic (${name}) is still running after ${warnTimeout / 1000}s, forget to call done()? For non-ending logic, set warnTimeout: 0`);
-        })
+        }))
         .subscribe();
     }
 
-    const dispatch$ = (new Subject())
-          .mergeAll()
-          .takeUntil(cancel$);
-    dispatch$
-      .do(
-        mapToActionAndDispatch, // next
-        mapErrorToActionAndDispatch // error
-      )
+    const dispatch$ = (new Subject()).pipe(mergeAll(), takeUntil(cancel$));
+    dispatch$.pipe(tap(// next
+    mapToActionAndDispatch, // error
+    mapErrorToActionAndDispatch))
       .subscribe({
         error: (/* err */) => {
           monitor$.next({ action, name, op: 'end' });
@@ -179,9 +160,9 @@ export default function createLogicAction$({ action, logic, store, deps, cancel$
         dispatch$.next( // create obs for mergeAll
           // eslint-disable-next-line no-nested-ternary
           (isObservable(act)) ? act :
-          (isPromise(act)) ? Observable.fromPromise(act) :
-          (act instanceof Error) ? Observable.throw(act) :
-          Observable.of(act)
+          (isPromise(act)) ? from(act) :
+          (act instanceof Error) ? throwError(act) :
+          of(act)
         );
       }
       if (!(dispatchMultiple || allowMore)) { dispatch$.complete(); }
@@ -289,7 +270,7 @@ export default function createLogicAction$({ action, logic, store, deps, cancel$
           // eslint-disable-next-line no-console
           console.error(`unhandled exception in logic named: ${name}`, err);
           // wrap in observable since might not be an error object
-          dispatch(Observable.throw(err));
+          dispatch(throwError(err));
         }
       } else { // not processing, must have been a reject
         dispatch$.complete();
@@ -311,9 +292,7 @@ export default function createLogicAction$({ action, logic, store, deps, cancel$
     }
 
     start();
-  })
-  .takeUntil(cancel$)
-  .take(1);
+  }).pipe(takeUntil(cancel$), take(1));
 
   return logicAction$;
 }

--- a/src/createLogicMiddleware.js
+++ b/src/createLogicMiddleware.js
@@ -1,11 +1,5 @@
-import { Observable } from 'rxjs/Observable'; // eslint-disable-line no-unused-vars
-import { Subject } from 'rxjs/Subject';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import 'rxjs/add/operator/filter';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/scan';
-import 'rxjs/add/operator/takeWhile';
-import 'rxjs/add/operator/toPromise';
+import {scan, takeWhile, map} from 'rxjs/operators';
+import { Observable, Subject, BehaviorSubject } from 'rxjs'; // eslint-disable-line no-unused-vars
 import wrapper from './logicWrapper';
 import { confirmProps, stringifyType } from './utils';
 
@@ -50,8 +44,7 @@ export default function createLogicMiddleware(arrLogic = [], deps = {}) {
   const actionSrc$ = new Subject(); // mw action stream
   const monitor$ = new Subject(); // monitor all activity
   const lastPending$ = new BehaviorSubject({ op: OP_INIT });
-  monitor$
-    .scan((acc, x) => { // append a pending logic count
+  monitor$.pipe(scan((acc, x) => { // append a pending logic count
       let pending = acc.pending || 0;
       switch (x.op) { // eslint-disable-line default-case
         case 'top' : // action at top of logic stack
@@ -74,7 +67,7 @@ export default function createLogicMiddleware(arrLogic = [], deps = {}) {
         ...x,
         pending
       };
-    }, { pending: 0 })
+    }, { pending: 0 }))
     .subscribe(lastPending$); // pipe to lastPending
 
   let savedStore;
@@ -121,10 +114,7 @@ export default function createLogicMiddleware(arrLogic = [], deps = {}) {
      @return {promise} promise resolves when all are complete
     */
   mw.whenComplete = function whenComplete(fn = identity) {
-    return lastPending$
-      // .do(x => console.log('wc', x)) /* keep commented out */
-      .takeWhile(x => x.pending)
-      .map((/* x */) => undefined) // not passing along anything
+    return lastPending$.pipe(takeWhile(x => x.pending), map((/* x */) => undefined))
       .toPromise()
       .then(fn);
   };

--- a/src/logicWrapper.js
+++ b/src/logicWrapper.js
@@ -2,7 +2,7 @@ import {debounceTime, throttleTime, share, filter, mergeMap} from 'rxjs/operator
 import { merge, Observable } from 'rxjs';
 import createLogicAction$ from './createLogicAction$';
 import { confirmProps } from './utils';
-
+// manual changes
 // confirm custom Rx build imports
 confirmProps(Observable, ['merge'], 'Observable');
 confirmProps(Observable.prototype, [

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import symbolObservable from 'symbol-observable';
+const symbolObservable = (Symbol && Symbol.observable) || '@@observable';
 
 // eslint-disable-next-line import/prefer-default-export
 export function confirmProps(obj, arrProps, objName = '') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 const symbolObservable = (Symbol && Symbol.observable) || '@@observable';
-
+// manual changes
 // eslint-disable-next-line import/prefer-default-export
 export function confirmProps(obj, arrProps, objName = '') {
   arrProps.forEach(x => {

--- a/test/createLogic.spec.js
+++ b/test/createLogic.spec.js
@@ -2,7 +2,7 @@ import {take, map, delay} from 'rxjs/operators';
 import expect from 'expect-legacy';
 import * as Rx from 'rxjs'
 import { createLogic, createLogicMiddleware, configureLogic } from '../src/index';
-
+// manual changes
 const NODE_ENV = process.env.NODE_ENV;
 
 describe('createLogic', () => {

--- a/test/createLogic.spec.js
+++ b/test/createLogic.spec.js
@@ -1,5 +1,6 @@
+import {take, map, delay} from 'rxjs/operators';
 import expect from 'expect-legacy';
-import Rx from 'rxjs';
+import * as Rx from 'rxjs'
 import { createLogic, createLogicMiddleware, configureLogic } from '../src/index';
 
 const NODE_ENV = process.env.NODE_ENV;
@@ -92,16 +93,9 @@ describe('createLogic', () => {
       });
       const mw = createLogicMiddleware([logicA]);
       const storeFn = mw({ dispatch })(next);
-      Rx.Observable.merge(
-        // fast 0, 1, 2
-        Rx.Observable.interval(10)
-          .take(3)
-          .map(x => ({ fast: x })),
-        // slow 0, 1, 2, 3
-        Rx.Observable.interval(60)
-          .take(4)
-          .delay(40)
-          .map(x => ({ slow: x }))
+      Rx.merge(
+        Rx.interval(10).pipe(take(3), map(x => ({ fast: x }))),
+        Rx.interval(60).pipe(take(4), delay(40), map(x => ({ slow: x })))
       ).subscribe(x => {
         storeFn({
           ...x,
@@ -143,16 +137,9 @@ describe('createLogic', () => {
       });
       const mw = createLogicMiddleware([logicA]);
       const storeFn = mw({ dispatch })(next);
-      Rx.Observable.merge(
-        // fast 0, 1, 2
-        Rx.Observable.interval(10)
-          .take(3)
-          .map(x => ({ fast: x })),
-        // slow 0, 1, 2, 3
-        Rx.Observable.interval(60)
-          .take(4)
-          .delay(40)
-          .map(x => ({ slow: x }))
+      Rx.merge(
+        Rx.interval(10).pipe(take(3), map(x => ({ fast: x }))),
+        Rx.interval(60).pipe(take(4), delay(40), map(x => ({ slow: x })))
       ).subscribe(x => {
         storeFn({
           ...x,
@@ -190,16 +177,9 @@ describe('createLogic', () => {
       });
       const mw = createLogicMiddleware([logicA]);
       const storeFn = mw({ dispatch })(next);
-      Rx.Observable.merge(
-        // fast 0, 1, 2
-        Rx.Observable.interval(10)
-          .take(3)
-          .map(x => ({ fast: x })),
-        // slow 0, 1, 2, 3
-        Rx.Observable.interval(60)
-          .take(4)
-          .delay(40)
-          .map(x => ({ slow: x }))
+      Rx.merge(
+        Rx.interval(10).pipe(take(3), map(x => ({ fast: x }))),
+        Rx.interval(60).pipe(take(4), delay(40), map(x => ({ slow: x })))
       ).subscribe({
         next: x => {
           storeFn({
@@ -243,16 +223,9 @@ describe('createLogic', () => {
       });
       const mw = createLogicMiddleware([logicA]);
       const storeFn = mw({ dispatch })(next);
-      Rx.Observable.merge(
-        // fast 0, 1, 2
-        Rx.Observable.interval(10)
-          .take(3)
-          .map(x => ({ fast: x })),
-        // slow 0, 1, 2, 3
-        Rx.Observable.interval(60)
-          .take(4)
-          .delay(40)
-          .map(x => ({ slow: x }))
+      Rx.merge(
+        Rx.interval(10).pipe(take(3), map(x => ({ fast: x }))),
+        Rx.interval(60).pipe(take(4), delay(40), map(x => ({ slow: x })))
       ).subscribe({
         next: x => {
           storeFn({
@@ -298,16 +271,9 @@ describe('createLogic', () => {
       });
       const mw = createLogicMiddleware([logicA]);
       const storeFn = mw({ dispatch })(next);
-      Rx.Observable.merge(
-        // fast 0, 1, 2
-        Rx.Observable.interval(10)
-          .take(3)
-          .map(x => ({ fast: x })),
-        // slow 0, 1, 2, 3
-        Rx.Observable.interval(60)
-          .take(4)
-          .delay(40)
-          .map(x => ({ slow: x }))
+      Rx.merge(
+        Rx.interval(10).pipe(take(3), map(x => ({ fast: x }))),
+        Rx.interval(60).pipe(take(4), delay(40), map(x => ({ slow: x })))
       ).subscribe({
         next: x => {
           storeFn({
@@ -352,16 +318,9 @@ describe('createLogic', () => {
       });
       const mw = createLogicMiddleware([logicA]);
       const storeFn = mw({ dispatch })(next);
-      Rx.Observable.merge(
-        // fast 0, 1, 2
-        Rx.Observable.interval(10)
-          .take(3)
-          .map(x => ({ fast: x })),
-        // slow 0, 1, 2, 3
-        Rx.Observable.interval(60)
-          .take(4)
-          .delay(40)
-          .map(x => ({ slow: x }))
+      Rx.merge(
+        Rx.interval(10).pipe(take(3), map(x => ({ fast: x }))),
+        Rx.interval(60).pipe(take(4), delay(40), map(x => ({ slow: x })))
       ).subscribe({
         next: x => {
           storeFn({

--- a/test/createLogicMiddleware-debounce.spec.js
+++ b/test/createLogicMiddleware-debounce.spec.js
@@ -1,4 +1,4 @@
-import Rx from 'rxjs';
+import * as Rx from 'rxjs'
 import expect from 'expect-legacy';
 import { createLogic, createLogicMiddleware, configureLogic } from '../src/index';
 

--- a/test/createLogicMiddleware-deps.spec.js
+++ b/test/createLogicMiddleware-deps.spec.js
@@ -1,4 +1,5 @@
-import Rx from 'rxjs';
+import {map} from 'rxjs/operators';
+import * as Rx from 'rxjs'
 import expect from 'expect-legacy';
 import { createLogic, createLogicMiddleware } from '../src/index';
 
@@ -239,8 +240,7 @@ describe('createLogicMiddleware-deps', () => {
               }, 10);
             }
           });
-          const ob$ = Rx.Observable.interval(1)
-                .map(x => ({ type: 'BAR', payload: x }));
+          const ob$ = Rx.interval(1).pipe(map(x => ({ type: 'BAR', payload: x })));
           dispatch(ob$);
 
           fireNextAction(); // manually triggering to get timing right

--- a/test/createLogicMiddleware-latest.spec.js
+++ b/test/createLogicMiddleware-latest.spec.js
@@ -1,4 +1,4 @@
-import Rx from 'rxjs';
+import * as Rx from 'rxjs'
 import expect from 'expect-legacy';
 import { createLogic, createLogicMiddleware } from '../src/index';
 

--- a/test/createLogicMiddleware-process.spec.js
+++ b/test/createLogicMiddleware-process.spec.js
@@ -1,4 +1,4 @@
-import Rx from 'rxjs';
+import * as Rx from 'rxjs'
 import expect from 'expect-legacy';
 import { createLogic, createLogicMiddleware } from '../src/index';
 
@@ -893,7 +893,7 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch) {
-          dispatch(Rx.Observable.of(actionBar, actionCat));
+          dispatch(Rx.of(actionBar, actionCat));
         }
       });
       mw = createLogicMiddleware([logicA]);
@@ -962,7 +962,7 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch) {
-          dispatch(Rx.Observable.of(actionBar, actionCat),
+          dispatch(Rx.of(actionBar, actionCat),
                    { allowMore: true });
           dispatch();
         }
@@ -1034,7 +1034,7 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch) {
-          dispatch(Rx.Observable.of(actionBar, actionCat),
+          dispatch(Rx.of(actionBar, actionCat),
                    { allowMore: true });
           dispatch(actionDog);
         }
@@ -1111,9 +1111,9 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch) {
-          dispatch(Rx.Observable.of(actionBar, actionCat),
+          dispatch(Rx.of(actionBar, actionCat),
                    { allowMore: true });
-          dispatch(Rx.Observable.of(actionDog, actionEgg),
+          dispatch(Rx.of(actionDog, actionEgg),
                    { allowMore: true });
           dispatch();
         }
@@ -1195,9 +1195,9 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch) {
-          dispatch(Rx.Observable.of(actionBar, actionCat),
+          dispatch(Rx.of(actionBar, actionCat),
                    { allowMore: true });
-          dispatch(Rx.Observable.of(actionDog, actionEgg),
+          dispatch(Rx.of(actionDog, actionEgg),
                    { allowMore: true });
           dispatch(actionFig);
         }
@@ -1283,7 +1283,7 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch, done) {
-          dispatch(Rx.Observable.of(actionBar, actionCat));
+          dispatch(Rx.of(actionBar, actionCat));
           dispatch();
           done();
         }
@@ -1355,7 +1355,7 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch, done) {
-          dispatch(Rx.Observable.of(actionBar, actionCat));
+          dispatch(Rx.of(actionBar, actionCat));
           dispatch(actionDog);
           done();
         }
@@ -1432,8 +1432,8 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch, done) {
-          dispatch(Rx.Observable.of(actionBar, actionCat));
-          dispatch(Rx.Observable.of(actionDog, actionEgg));
+          dispatch(Rx.of(actionBar, actionCat));
+          dispatch(Rx.of(actionDog, actionEgg));
           done();
         }
       });
@@ -1514,8 +1514,8 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch, done) {
-          dispatch(Rx.Observable.of(actionBar, actionCat));
-          dispatch(Rx.Observable.of(actionDog, actionEgg));
+          dispatch(Rx.of(actionBar, actionCat));
+          dispatch(Rx.of(actionDog, actionEgg));
           dispatch(actionFig);
           done();
         }

--- a/test/createLogicMiddleware-throttle.spec.js
+++ b/test/createLogicMiddleware-throttle.spec.js
@@ -1,4 +1,4 @@
-import Rx from 'rxjs';
+import * as Rx from 'rxjs'
 import expect from 'expect-legacy';
 import { createLogic, createLogicMiddleware, configureLogic } from '../src/index';
 


### PR DESCRIPTION
This pull request is generated by JSFix and updates rxjs to version 6.0.0.

 The following breaking changes affects the new code:
* Dropping support for non-LTS versions of Node.