### PR TITLE
Update rxjs to version 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "is-promise": "^2.1.0",
     "loose-envify": "^1.4.0",
-    "rxjs": "^5.5.11",
+    "rxjs": "^6.0.0",
     "symbol-observable": "^1.2.0"
   },
   "peerDependencies": {

--- a/src/createLogic.js
+++ b/src/createLogic.js
@@ -1,3 +1,4 @@
+import {map} from 'rxjs/operators';
 import { stringifyType } from './utils';
 
 const allowedOptions = [
@@ -241,7 +242,7 @@ function getInvalidOptions(options, validOptions) {
 /* if type is a fn call toString() to get type, redux-actions
   if array, then check members */
 function typeToStrFns(type) {
-  if (Array.isArray(type)) { return type.map(x => typeToStrFns(x)); }
+  if (Array.isArray(type)) { return type.pipe(map(x => typeToStrFns(x))); }
   return (typeof type === 'function') ?
     type.toString() :
     type;

--- a/src/createLogicAction$.js
+++ b/src/createLogicAction$.js
@@ -62,8 +62,7 @@ export default function createLogicAction$({ action, logic, store, deps, cancel$
     if (NODE_ENV !== 'production' && warnTimeout) {
       Observable.timer(warnTimeout)
         // take until cancelled, errored, or completed
-        .takeUntil(cancelled$.defaultIfEmpty(true))
-        .do(() => {
+        .takeUntil(cancelled$.defaultIfEmpty(true)).tap(() => {
           // eslint-disable-next-line no-console
           console.error(`warning: logic (${name}) is still running after ${warnTimeout / 1000}s, forget to call done()? For non-ending logic, set warnTimeout: 0`);
         })
@@ -73,8 +72,7 @@ export default function createLogicAction$({ action, logic, store, deps, cancel$
     const dispatch$ = (new Subject())
           .mergeAll()
           .takeUntil(cancel$);
-    dispatch$
-      .do(
+    dispatch$.tap(
         mapToActionAndDispatch, // next
         mapErrorToActionAndDispatch // error
       )

--- a/src/createLogicMiddleware.js
+++ b/src/createLogicMiddleware.js
@@ -1,11 +1,5 @@
-import { Observable } from 'rxjs/Observable'; // eslint-disable-line no-unused-vars
-import { Subject } from 'rxjs/Subject';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import 'rxjs/add/operator/filter';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/scan';
-import 'rxjs/add/operator/takeWhile';
-import 'rxjs/add/operator/toPromise';
+import {scan, takeWhile, map, filter, reduce} from 'rxjs/operators';
+import { concat, Observable, Subject, BehaviorSubject } from 'rxjs';
 import wrapper from './logicWrapper';
 import { confirmProps, stringifyType } from './utils';
 
@@ -50,8 +44,7 @@ export default function createLogicMiddleware(arrLogic = [], deps = {}) {
   const actionSrc$ = new Subject(); // mw action stream
   const monitor$ = new Subject(); // monitor all activity
   const lastPending$ = new BehaviorSubject({ op: OP_INIT });
-  monitor$
-    .scan((acc, x) => { // append a pending logic count
+  monitor$.pipe(scan((acc, x) => { // append a pending logic count
       let pending = acc.pending || 0;
       switch (x.op) { // eslint-disable-line default-case
         case 'top' : // action at top of logic stack
@@ -74,7 +67,7 @@ export default function createLogicMiddleware(arrLogic = [], deps = {}) {
         ...x,
         pending
       };
-    }, { pending: 0 })
+    }, { pending: 0 }))
     .subscribe(lastPending$); // pipe to lastPending
 
   let savedStore;
@@ -121,10 +114,7 @@ export default function createLogicMiddleware(arrLogic = [], deps = {}) {
      @return {promise} promise resolves when all are complete
     */
   mw.whenComplete = function whenComplete(fn = identity) {
-    return lastPending$
-      // .do(x => console.log('wc', x)) /* keep commented out */
-      .takeWhile(x => x.pending)
-      .map((/* x */) => undefined) // not passing along anything
+    return lastPending$.pipe(takeWhile(x => x.pending), map((/* x */) => undefined))
       .toPromise()
       .then(fn);
   };
@@ -161,7 +151,7 @@ export default function createLogicMiddleware(arrLogic = [], deps = {}) {
    */
   mw.addLogic = function addLogic(arrNewLogic) {
     if (!arrNewLogic.length) { return { logicCount }; }
-    const combinedLogic = savedLogicArr.concat(arrNewLogic);
+    const combinedLogic = concat(savedLogicArr, arrNewLogic);
     const duplicateLogic = findDuplicates(combinedLogic);
     if (duplicateLogic.length) {
       throw new Error(`duplicate logic, indexes: ${duplicateLogic}`);
@@ -184,8 +174,8 @@ export default function createLogicMiddleware(arrLogic = [], deps = {}) {
       throw new Error(`duplicate logic, indexes: ${duplicateLogic}`);
     }
     // filter out any refs that match existing logic, then addLogic
-    const arrNewLogic = arrMergeLogic.filter(x =>
-      savedLogicArr.indexOf(x) === -1);
+    const arrNewLogic = arrMergeLogic.pipe(filter(x =>
+      savedLogicArr.indexOf(x) === -1));
     return mw.addLogic(arrNewLogic);
   };
 
@@ -220,12 +210,11 @@ function applyLogic(arrLogic, store, next, sub, actionIn$, deps,
 
   if (sub) { sub.unsubscribe(); }
 
-  const wrappedLogic = arrLogic.map((logic, idx) => {
+  const wrappedLogic = arrLogic.pipe(map((logic, idx) => {
     const namedLogic = naming(logic, idx + startLogicCount);
     return wrapper(namedLogic, store, deps, monitor$);
-  });
-  const actionOut$ = wrappedLogic.reduce((acc$, wep) => wep(acc$),
-                                         actionIn$);
+  }));
+  const actionOut$ = wrappedLogic.pipe(reduce((acc$, wep) => wep(acc$), actionIn$));
   const newSub = actionOut$.subscribe(action => {
     debug('actionEnd$', action);
     try {
@@ -268,10 +257,10 @@ function naming(logic, idx) {
   @return {array} array of indexes to duplicates, empty array if none
  */
 function findDuplicates(arrLogic) {
-  return arrLogic.reduce((acc, x1, idx1) => {
+  return arrLogic.pipe(reduce((acc, x1, idx1) => {
     if (arrLogic.some((x2, idx2) => (idx1 !== idx2 && x1 === x2))) {
       acc.push(idx1);
     }
     return acc;
-  }, []);
+  }, []));
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
-import symbolObservable from 'symbol-observable';
+import {map} from 'rxjs/operators';
+const symbolObservable = (Symbol && Symbol.observable) || '@@observable';
 
 // eslint-disable-next-line import/prefer-default-export
 export function confirmProps(obj, arrProps, objName = '') {
@@ -14,7 +15,7 @@ export function confirmProps(obj, arrProps, objName = '') {
 // eslint-disable-next-line import/prefer-default-export
 export function stringifyType(type) {
   return Array.isArray(type) ?
-         type.map(type => type.toString()) :
+         type.pipe(map(type => type.toString())) :
          type.toString();
 }
 

--- a/test/createLogic.spec.js
+++ b/test/createLogic.spec.js
@@ -1,5 +1,6 @@
+import {take, map, delay} from 'rxjs/operators';
 import expect from 'expect-legacy';
-import Rx from 'rxjs';
+import * as Rx from 'rxjs'
 import { createLogic, createLogicMiddleware, configureLogic } from '../src/index';
 
 const NODE_ENV = process.env.NODE_ENV;
@@ -92,16 +93,9 @@ describe('createLogic', () => {
       });
       const mw = createLogicMiddleware([logicA]);
       const storeFn = mw({ dispatch })(next);
-      Rx.Observable.merge(
-        // fast 0, 1, 2
-        Rx.Observable.interval(10)
-          .take(3)
-          .map(x => ({ fast: x })),
-        // slow 0, 1, 2, 3
-        Rx.Observable.interval(60)
-          .take(4)
-          .delay(40)
-          .map(x => ({ slow: x }))
+      Rx.merge(
+        Rx.interval(10).pipe(take(3), map(x => ({ fast: x }))),
+        Rx.interval(60).pipe(take(4), delay(40), map(x => ({ slow: x })))
       ).subscribe(x => {
         storeFn({
           ...x,
@@ -143,16 +137,9 @@ describe('createLogic', () => {
       });
       const mw = createLogicMiddleware([logicA]);
       const storeFn = mw({ dispatch })(next);
-      Rx.Observable.merge(
-        // fast 0, 1, 2
-        Rx.Observable.interval(10)
-          .take(3)
-          .map(x => ({ fast: x })),
-        // slow 0, 1, 2, 3
-        Rx.Observable.interval(60)
-          .take(4)
-          .delay(40)
-          .map(x => ({ slow: x }))
+      Rx.merge(
+        Rx.interval(10).pipe(take(3), map(x => ({ fast: x }))),
+        Rx.interval(60).pipe(take(4), delay(40), map(x => ({ slow: x })))
       ).subscribe(x => {
         storeFn({
           ...x,
@@ -190,16 +177,9 @@ describe('createLogic', () => {
       });
       const mw = createLogicMiddleware([logicA]);
       const storeFn = mw({ dispatch })(next);
-      Rx.Observable.merge(
-        // fast 0, 1, 2
-        Rx.Observable.interval(10)
-          .take(3)
-          .map(x => ({ fast: x })),
-        // slow 0, 1, 2, 3
-        Rx.Observable.interval(60)
-          .take(4)
-          .delay(40)
-          .map(x => ({ slow: x }))
+      Rx.merge(
+        Rx.interval(10).pipe(take(3), map(x => ({ fast: x }))),
+        Rx.interval(60).pipe(take(4), delay(40), map(x => ({ slow: x })))
       ).subscribe({
         next: x => {
           storeFn({
@@ -243,16 +223,9 @@ describe('createLogic', () => {
       });
       const mw = createLogicMiddleware([logicA]);
       const storeFn = mw({ dispatch })(next);
-      Rx.Observable.merge(
-        // fast 0, 1, 2
-        Rx.Observable.interval(10)
-          .take(3)
-          .map(x => ({ fast: x })),
-        // slow 0, 1, 2, 3
-        Rx.Observable.interval(60)
-          .take(4)
-          .delay(40)
-          .map(x => ({ slow: x }))
+      Rx.merge(
+        Rx.interval(10).pipe(take(3), map(x => ({ fast: x }))),
+        Rx.interval(60).pipe(take(4), delay(40), map(x => ({ slow: x })))
       ).subscribe({
         next: x => {
           storeFn({
@@ -298,16 +271,9 @@ describe('createLogic', () => {
       });
       const mw = createLogicMiddleware([logicA]);
       const storeFn = mw({ dispatch })(next);
-      Rx.Observable.merge(
-        // fast 0, 1, 2
-        Rx.Observable.interval(10)
-          .take(3)
-          .map(x => ({ fast: x })),
-        // slow 0, 1, 2, 3
-        Rx.Observable.interval(60)
-          .take(4)
-          .delay(40)
-          .map(x => ({ slow: x }))
+      Rx.merge(
+        Rx.interval(10).pipe(take(3), map(x => ({ fast: x }))),
+        Rx.interval(60).pipe(take(4), delay(40), map(x => ({ slow: x })))
       ).subscribe({
         next: x => {
           storeFn({
@@ -352,16 +318,9 @@ describe('createLogic', () => {
       });
       const mw = createLogicMiddleware([logicA]);
       const storeFn = mw({ dispatch })(next);
-      Rx.Observable.merge(
-        // fast 0, 1, 2
-        Rx.Observable.interval(10)
-          .take(3)
-          .map(x => ({ fast: x })),
-        // slow 0, 1, 2, 3
-        Rx.Observable.interval(60)
-          .take(4)
-          .delay(40)
-          .map(x => ({ slow: x }))
+      Rx.merge(
+        Rx.interval(10).pipe(take(3), map(x => ({ fast: x }))),
+        Rx.interval(60).pipe(take(4), delay(40), map(x => ({ slow: x })))
       ).subscribe({
         next: x => {
           storeFn({

--- a/test/createLogicMiddleware-debounce.spec.js
+++ b/test/createLogicMiddleware-debounce.spec.js
@@ -1,4 +1,4 @@
-import Rx from 'rxjs';
+import * as Rx from 'rxjs'
 import expect from 'expect-legacy';
 import { createLogic, createLogicMiddleware, configureLogic } from '../src/index';
 

--- a/test/createLogicMiddleware-deps.spec.js
+++ b/test/createLogicMiddleware-deps.spec.js
@@ -1,4 +1,5 @@
-import Rx from 'rxjs';
+import {map} from 'rxjs/operators';
+import * as Rx from 'rxjs'
 import expect from 'expect-legacy';
 import { createLogic, createLogicMiddleware } from '../src/index';
 
@@ -239,8 +240,7 @@ describe('createLogicMiddleware-deps', () => {
               }, 10);
             }
           });
-          const ob$ = Rx.Observable.interval(1)
-                .map(x => ({ type: 'BAR', payload: x }));
+          const ob$ = Rx.interval(1).pipe(map(x => ({ type: 'BAR', payload: x })));
           dispatch(ob$);
 
           fireNextAction(); // manually triggering to get timing right

--- a/test/createLogicMiddleware-latest.spec.js
+++ b/test/createLogicMiddleware-latest.spec.js
@@ -1,4 +1,4 @@
-import Rx from 'rxjs';
+import * as Rx from 'rxjs'
 import expect from 'expect-legacy';
 import { createLogic, createLogicMiddleware } from '../src/index';
 

--- a/test/createLogicMiddleware-process.spec.js
+++ b/test/createLogicMiddleware-process.spec.js
@@ -1,4 +1,4 @@
-import Rx from 'rxjs';
+import * as Rx from 'rxjs'
 import expect from 'expect-legacy';
 import { createLogic, createLogicMiddleware } from '../src/index';
 
@@ -893,7 +893,7 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch) {
-          dispatch(Rx.Observable.of(actionBar, actionCat));
+          dispatch(Rx.of(actionBar, actionCat));
         }
       });
       mw = createLogicMiddleware([logicA]);
@@ -962,7 +962,7 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch) {
-          dispatch(Rx.Observable.of(actionBar, actionCat),
+          dispatch(Rx.of(actionBar, actionCat),
                    { allowMore: true });
           dispatch();
         }
@@ -1034,7 +1034,7 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch) {
-          dispatch(Rx.Observable.of(actionBar, actionCat),
+          dispatch(Rx.of(actionBar, actionCat),
                    { allowMore: true });
           dispatch(actionDog);
         }
@@ -1111,9 +1111,9 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch) {
-          dispatch(Rx.Observable.of(actionBar, actionCat),
+          dispatch(Rx.of(actionBar, actionCat),
                    { allowMore: true });
-          dispatch(Rx.Observable.of(actionDog, actionEgg),
+          dispatch(Rx.of(actionDog, actionEgg),
                    { allowMore: true });
           dispatch();
         }
@@ -1195,9 +1195,9 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch) {
-          dispatch(Rx.Observable.of(actionBar, actionCat),
+          dispatch(Rx.of(actionBar, actionCat),
                    { allowMore: true });
-          dispatch(Rx.Observable.of(actionDog, actionEgg),
+          dispatch(Rx.of(actionDog, actionEgg),
                    { allowMore: true });
           dispatch(actionFig);
         }
@@ -1283,7 +1283,7 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch, done) {
-          dispatch(Rx.Observable.of(actionBar, actionCat));
+          dispatch(Rx.of(actionBar, actionCat));
           dispatch();
           done();
         }
@@ -1355,7 +1355,7 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch, done) {
-          dispatch(Rx.Observable.of(actionBar, actionCat));
+          dispatch(Rx.of(actionBar, actionCat));
           dispatch(actionDog);
           done();
         }
@@ -1432,8 +1432,8 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch, done) {
-          dispatch(Rx.Observable.of(actionBar, actionCat));
-          dispatch(Rx.Observable.of(actionDog, actionEgg));
+          dispatch(Rx.of(actionBar, actionCat));
+          dispatch(Rx.of(actionDog, actionEgg));
           done();
         }
       });
@@ -1514,8 +1514,8 @@ describe('createLogicMiddleware-process', () => {
       logicA = createLogic({
         type: 'FOO',
         process(deps, dispatch, done) {
-          dispatch(Rx.Observable.of(actionBar, actionCat));
-          dispatch(Rx.Observable.of(actionDog, actionEgg));
+          dispatch(Rx.of(actionBar, actionCat));
+          dispatch(Rx.of(actionDog, actionEgg));
           dispatch(actionFig);
           done();
         }

--- a/test/createLogicMiddleware-throttle.spec.js
+++ b/test/createLogicMiddleware-throttle.spec.js
@@ -1,4 +1,4 @@
-import Rx from 'rxjs';
+import * as Rx from 'rxjs'
 import expect from 'expect-legacy';
 import { createLogic, createLogicMiddleware, configureLogic } from '../src/index';
 


### PR DESCRIPTION
This pull request was created using the JSFIX program analysis (https://jsfix.live) by Coana.tech (https://coana.tech)

It bumps rxjs to version 6.0.0

JSFIX has adapted your code to all breaking changes introduced in rxjs version 6.0.0

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request<details>
<summary>Click to show list of patched breaking changes</summary>
* creation functions: All create functions such as of, from, combineLatest and fromEvent should now be imported from rxjs/create.

  - [src/createLogicAction$.js#L63](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L63)

  - [src/createLogicAction$.js#L182](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L182)

  - [src/createLogicAction$.js#L183](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L183)

  - [src/createLogicAction$.js#L184](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L184)

  - [src/createLogicAction$.js#L292](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L292)

  - [src/logicWrapper.js#L55](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L55)

  - [test/createLogic.spec.js#L95](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L95)

  - [test/createLogic.spec.js#L97](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L97)

  - [test/createLogic.spec.js#L101](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L101)

  - [test/createLogic.spec.js#L146](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L146)

  - [test/createLogic.spec.js#L148](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L148)

  - [test/createLogic.spec.js#L152](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L152)

  - [test/createLogic.spec.js#L193](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L193)

  - [test/createLogic.spec.js#L195](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L195)

  - [test/createLogic.spec.js#L199](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L199)

  - [test/createLogic.spec.js#L246](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L246)

  - [test/createLogic.spec.js#L248](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L248)

  - [test/createLogic.spec.js#L252](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L252)

  - [test/createLogic.spec.js#L301](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L301)

  - [test/createLogic.spec.js#L303](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L303)

  - [test/createLogic.spec.js#L307](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L307)

  - [test/createLogic.spec.js#L355](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L355)

  - [test/createLogic.spec.js#L357](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L357)

  - [test/createLogic.spec.js#L361](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L361)

  - [test/createLogicMiddleware-deps.spec.js#L242](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-deps.spec.js#L242)

  - [test/createLogicMiddleware-process.spec.js#L896](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L896)

  - [test/createLogicMiddleware-process.spec.js#L965](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L965)

  - [test/createLogicMiddleware-process.spec.js#L1037](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L1037)

  - [test/createLogicMiddleware-process.spec.js#L1114](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L1114)

  - [test/createLogicMiddleware-process.spec.js#L1116](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L1116)

  - [test/createLogicMiddleware-process.spec.js#L1198](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L1198)

  - [test/createLogicMiddleware-process.spec.js#L1200](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L1200)

  - [test/createLogicMiddleware-process.spec.js#L1286](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L1286)

  - [test/createLogicMiddleware-process.spec.js#L1358](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L1358)

  - [test/createLogicMiddleware-process.spec.js#L1435](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L1435)

  - [test/createLogicMiddleware-process.spec.js#L1436](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L1436)

  - [test/createLogicMiddleware-process.spec.js#L1517](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L1517)

  - [test/createLogicMiddleware-process.spec.js#L1518](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L1518)

* deep imports: Can no longer deep import top-level types such as rxjs/Observable, rxjs/Subject, rxjs/ReplaySubject, et al. All imports should be done directly from rxjs, for example: import \{ Observable, Subject \} from 'rxjs';

  - [src/createLogicAction$.js#L2](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L2)

  - [src/createLogicAction$.js#L3](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L3)

  - [src/createLogicMiddleware.js#L1](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L1)

  - [src/createLogicMiddleware.js#L2](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L2)

  - [src/createLogicMiddleware.js#L3](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L3)

  - [src/logicWrapper.js#L1](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L1)

* operators removed: Operator versions of static observable creators such as merge, concat, zip, onErrorResumeNext, and race have been removed. Please use the static versions of those operations. e.g. a.pipe(concat(b, c)) becomes concat(a, b, c).

  - [src/createLogicMiddleware.js#L164](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L164)

* Removed fromPromise, should use from instead.

  - [src/createLogicAction$.js#L182](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L182)

* Removed default import such that import Rx from 'rxjs'; fails. Instead import * as Rx from 'rxjs'; works

  - [test/createLogic.spec.js#L2](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L2)

  - [test/createLogicMiddleware-debounce.spec.js#L1](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-debounce.spec.js#L1)

  - [test/createLogicMiddleware-deps.spec.js#L1](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-deps.spec.js#L1)

  - [test/createLogicMiddleware-latest.spec.js#L1](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-latest.spec.js#L1)

  - [test/createLogicMiddleware-process.spec.js#L1](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-process.spec.js#L1)

  - [test/createLogicMiddleware-throttle.spec.js#L1](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-throttle.spec.js#L1)

* Dropping support for chaining operators (use pipe instead)

  - [src/createLogic.js#L244](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogic.js#L244)

  - [src/createLogicAction$.js#L45](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L45)

  - [src/createLogicAction$.js#L65](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L65)

  - [src/createLogicAction$.js#L63](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L63)

  - [src/createLogicAction$.js#L63](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L63)

  - [src/createLogicAction$.js#L73](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L73)

  - [src/createLogicAction$.js#L73](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L73)

  - [src/createLogicAction$.js#L76](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L76)

  - [src/createLogicAction$.js#L42](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L42)

  - [src/createLogicAction$.js#L42](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L42)

  - [src/createLogicMiddleware.js#L53](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L53)

  - [src/createLogicMiddleware.js#L124](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L124)

  - [src/createLogicMiddleware.js#L124](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L124)

  - [src/createLogicMiddleware.js#L187](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L187)

  - [src/createLogicMiddleware.js#L223](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L223)

  - [src/createLogicMiddleware.js#L227](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L227)

  - [src/createLogicMiddleware.js#L271](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L271)

  - [src/logicWrapper.js#L27](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L27)

  - [src/logicWrapper.js#L31](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L31)

  - [src/logicWrapper.js#L39](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L39)

  - [src/logicWrapper.js#L42](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L42)

  - [src/logicWrapper.js#L46](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L46)

  - [src/logicWrapper.js#L50](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L50)

  - [src/logicWrapper.js#L50](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L50)

  - [test/createLogic.spec.js#L97](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L97)

  - [test/createLogic.spec.js#L97](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L97)

  - [test/createLogic.spec.js#L101](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L101)

  - [test/createLogic.spec.js#L101](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L101)

  - [test/createLogic.spec.js#L101](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L101)

  - [test/createLogic.spec.js#L148](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L148)

  - [test/createLogic.spec.js#L148](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L148)

  - [test/createLogic.spec.js#L152](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L152)

  - [test/createLogic.spec.js#L152](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L152)

  - [test/createLogic.spec.js#L152](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L152)

  - [test/createLogic.spec.js#L195](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L195)

  - [test/createLogic.spec.js#L195](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L195)

  - [test/createLogic.spec.js#L199](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L199)

  - [test/createLogic.spec.js#L199](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L199)

  - [test/createLogic.spec.js#L199](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L199)

  - [test/createLogic.spec.js#L248](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L248)

  - [test/createLogic.spec.js#L248](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L248)

  - [test/createLogic.spec.js#L252](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L252)

  - [test/createLogic.spec.js#L252](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L252)

  - [test/createLogic.spec.js#L252](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L252)

  - [test/createLogic.spec.js#L303](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L303)

  - [test/createLogic.spec.js#L303](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L303)

  - [test/createLogic.spec.js#L307](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L307)

  - [test/createLogic.spec.js#L307](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L307)

  - [test/createLogic.spec.js#L307](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L307)

  - [test/createLogic.spec.js#L357](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L357)

  - [test/createLogic.spec.js#L357](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L357)

  - [test/createLogic.spec.js#L361](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L361)

  - [test/createLogic.spec.js#L361](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L361)

  - [test/createLogic.spec.js#L361](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogic.spec.js#L361)

  - [src/utils.js#L17](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/utils.js#L17)

  - [test/createLogicMiddleware-deps.spec.js#L242](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/test/createLogicMiddleware-deps.spec.js#L242)

* Dropping support for chaining operators (use pipe instead)

  - [src/createLogicAction$.js#L4](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L4)

  - [src/createLogicAction$.js#L5](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L5)

  - [src/createLogicAction$.js#L6](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L6)

  - [src/createLogicAction$.js#L7](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L7)

  - [src/createLogicAction$.js#L8](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L8)

  - [src/createLogicAction$.js#L9](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L9)

  - [src/createLogicAction$.js#L10](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L10)

  - [src/createLogicAction$.js#L11](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L11)

  - [src/createLogicAction$.js#L12](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L12)

  - [src/createLogicAction$.js#L13](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L13)

  - [src/createLogicAction$.js#L14](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L14)

  - [src/createLogicMiddleware.js#L4](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L4)

  - [src/createLogicMiddleware.js#L5](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L5)

  - [src/createLogicMiddleware.js#L6](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L6)

  - [src/createLogicMiddleware.js#L7](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L7)

  - [src/createLogicMiddleware.js#L8](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicMiddleware.js#L8)

  - [src/logicWrapper.js#L2](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L2)

  - [src/logicWrapper.js#L3](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L3)

  - [src/logicWrapper.js#L4](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L4)

  - [src/logicWrapper.js#L5](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L5)

  - [src/logicWrapper.js#L6](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L6)

  - [src/logicWrapper.js#L7](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/logicWrapper.js#L7)

* Operator renames: do -> tap, catch -> catchError, switch -> switchAll, finally -> finalize, throw -> throwError


  - [src/createLogicAction$.js#L63](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L63)

  - [src/createLogicAction$.js#L76](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L76)

* Operator renames: do -> tap, catch -> catchError, switch -> switchAll, finally -> finalize, throw -> throwError


  - [src/createLogicAction$.js#L6](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L6)

* Operator renames: do -> tap, catch -> catchError, switch -> switchAll, finally -> finalize, throw -> throwError


  - [src/createLogicAction$.js#L183](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L183)

  - [src/createLogicAction$.js#L292](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/createLogicAction$.js#L292)

* rxjs@6.0.0 is incompatible with the npm package symbol-observable

  - [src/utils.js#L1](https://github.com/mtorp/redux-logic/mono/blob/87de200330f8e3609a92715be4f64ce216735acc/src/utils.js#L1)

</details>
